### PR TITLE
Changed the EDN lexer to take in a `io.Reader`.

### DIFF
--- a/edn/lexer.go
+++ b/edn/lexer.go
@@ -15,10 +15,14 @@
 package edn
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
 	"github.com/timtadh/lexmachine"
 	"github.com/timtadh/lexmachine/machines"
-	"strings"
 )
 
 type PrimitiveType int
@@ -74,7 +78,7 @@ type Lexer interface {
 
 	AddCollectionPattern(start string, end string, processor CollectionProcessor)
 
-	Parse(data string) (Element, error)
+	Parse(data io.Reader) (Element, error)
 }
 
 func splitTag(data []byte, possible string) (tag string, value string) {
@@ -148,6 +152,7 @@ type lexerImpl struct {
 	collectionPatterns map[string]*collProcDef
 	lex                *lexmachine.Lexer
 	built              bool
+	patternAdder       func([]byte, lexmachine.Action)
 }
 
 // newLexer will create a new lexer.
@@ -163,7 +168,7 @@ func newLexer() (lexer Lexer, err error) {
 }
 
 // completeStartup of the lexer
-func (lexer *lexerImpl) completeStartup() (err error) {
+func (lexer *lexerImpl) completeStartup() error {
 
 	if !lexer.built {
 
@@ -248,32 +253,47 @@ func (lexer *lexerImpl) completeStartup() (err error) {
 		})
 
 		compile := lexer.lex.CompileNFA
-		if err = compile(); err == nil {
-			lexer.built = true
+		if err := compile(); err != nil {
+			return err
 		}
+		lexer.built = true
 	}
 
-	return err
+	return nil
 }
 
 // Parse the value
-func (lexer *lexerImpl) Parse(data string) (elem Element, err error) {
-	if err = lexer.completeStartup(); err == nil {
-		var scanner *lexmachine.Scanner
-		if scanner, err = lexer.lex.Scanner([]byte(data)); err == nil {
-			var elems []Element
-			if _, elems, err = runScanner(scanner); err == nil {
-				switch {
-				case len(elems) == 1:
-					elem = elems[0]
-				default:
-					err = MakeErrorWithFormat(ErrParserError, "Expected one result, got: %d", len(elems))
-				}
-			}
-		}
+func (lexer *lexerImpl) Parse(data io.Reader) (elem Element, err error) {
+
+	if data == nil {
+		return nil, MakeErrorWithFormat(ErrParserError, "parse input was nil")
 	}
 
-	return elem, err
+	var bytes []byte
+	if bytes, err = ioutil.ReadAll(data); err != nil {
+		return nil, MakeErrorWithFormat(ErrParserError, "parse input error: %s", err.Error())
+	}
+
+	if err = lexer.completeStartup(); err != nil {
+		return nil, err
+	}
+
+	var scanner *lexmachine.Scanner
+	if scanner, err = lexer.lex.Scanner(bytes); err == nil {
+		return nil, err
+	}
+
+	var elems []Element
+	if _, elems, err = runScanner(scanner); err != nil {
+		return nil, err
+	}
+
+	switch {
+	case len(elems) == 1:
+		return elems[0], nil
+	default:
+		return nil, MakeErrorWithFormat(ErrParserError, "Expected one result, got: %d", len(elems))
+	}
 }
 
 // AddPattern will add a pattern to the lexer
@@ -302,54 +322,56 @@ func (lexer *lexerImpl) AddCollectionPattern(start string, end string, processor
 }
 
 func (lexer *lexerImpl) addPattern(pattern []byte, action lexmachine.Action) {
+	if lexer.patternAdder != nil {
+		lexer.patternAdder(pattern, action)
+		return
+	}
 
 	lexer.lex.Add(pattern, action)
+}
 
-	// NOTE:
-	//   The following code here is to diagnose pattern issues.
+func (lexer *lexerImpl) addPatternDebugger(pattern []byte, action lexmachine.Action) {
+	lexer.lex.Add(pattern, action)
 
-	/*
+	fmt.Println("Pattern: ", string(pattern))
+	lex := lexmachine.NewLexer()
 
-		fmt.Println("Pattern: ", string(pattern))
-		lex := lexmachine.NewLexer()
+	lex.Add([]byte(pattern), func(scan *lexmachine.Scanner, match *machines.Match) (interface{}, error) {
+		fmt.Println("  Matches empty: ", string(pattern))
+		return true, nil
+	})
 
-		lex.Add([]byte(pattern), func(scan *lexmachine.Scanner, match *machines.Match) (interface{}, error) {
-			fmt.Println("  Matches empty: ", string(pattern))
-			return true, nil
-		})
+	compile := lex.CompileNFA
 
-		compile := lex.CompileNFA
+	var err error
+	if err = compile(); err == nil {
 
-		var err error
-		if err = compile(); err == nil {
+		var s *lexmachine.Scanner
+		if s, err = lex.Scanner([]byte("")); err == nil {
 
-			var s *lexmachine.Scanner
-			if s, err = lex.Scanner([]byte("")); err == nil {
+			var tok interface{}
+			var end bool
 
-				var tok interface{}
-				var end bool
-
-				if tok, err, end = s.Next(); err == nil {
-					if !end {
-						err = errors.New("expected an end of string")
-					} else {
-						if tok != nil {
-							switch v := tok.(type) {
-							case bool:
-								if v {
-									err = errors.New("expected false")
-								}
-							default:
-								err = errors.New(fmt.Sprintf("expected a bool: %#v", tok))
+			if tok, err, end = s.Next(); err == nil {
+				if !end {
+					err = errors.New("expected an end of string")
+				} else {
+					if tok != nil {
+						switch v := tok.(type) {
+						case bool:
+							if v {
+								err = errors.New("expected false")
 							}
+						default:
+							err = errors.New(fmt.Sprintf("expected a bool: %#v", tok))
 						}
 					}
 				}
 			}
 		}
+	}
 
-		if err != nil {
-			fmt.Println("  Error: ", err)
-		}
-	*/
+	if err != nil {
+		fmt.Println("  Error: ", err)
+	}
 }

--- a/edn/map_test.go
+++ b/edn/map_test.go
@@ -15,6 +15,8 @@
 package edn
 
 import (
+	"fmt"
+
 	"github.com/Workiva/eva-client-go/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -424,25 +426,25 @@ var _ = Describe("Map in EDN", func() {
 		})
 
 		It("should break the creation if there is an error", func() {
-			_, err := Parse("{ :foo }")
+			_, err := ParseString("{ :foo }")
 			Ω(err).ShouldNot(BeNil())
 			Ω(err).Should(test.HaveMessage(ErrInvalidPair))
 		})
 
 		It("should break the creation if there is an error", func() {
-			_, err := Parse("{ :foo 2 ]")
+			_, err := ParseString("{ :foo 2 ]")
 			Ω(err).ShouldNot(BeNil())
 			Ω(err).Should(test.HaveMessage(ErrParserError))
 		})
 
 		It("should break the creation if there is an error", func() {
-			_, err := Parse("{ :foo 2 :taco")
+			_, err := ParseString("{ :foo 2 :taco")
 			Ω(err).ShouldNot(BeNil())
 			Ω(err).Should(test.HaveMessage(ErrParserError))
 		})
 
 		It("should break the creation if there is an error", func() {
-			_, err := Parse("{ :foo 2 \n\t")
+			_, err := ParseString("{ :foo 2 \n\t")
 			Ω(err).ShouldNot(BeNil())
 			Ω(err).Should(test.HaveMessage(ErrParserError))
 		})
@@ -481,7 +483,9 @@ var _ = Describe("Map in EDN", func() {
 
 				if err == nil {
 					t := NewIntegerElement(1)
-					t.SetTag("foo")
+					if e := t.SetTag("foo"); e != nil {
+						Fail(fmt.Sprintf("should not have gotten this: %s", e))
+					}
 					elements = map[string][2]Element{
 						"#foo 1": {t, NewIntegerElement(2)},
 					}

--- a/edn/parser.go
+++ b/edn/parser.go
@@ -14,6 +14,11 @@
 
 package edn
 
+import (
+	"io"
+	"strings"
+)
+
 const (
 	ErrParserError = ErrorMessage("Parser error")
 )
@@ -32,7 +37,17 @@ func getLexer() (lexer Lexer, err error) {
 }
 
 // Parse the string into an edn element.
-func Parse(data string) (elem Element, err error) {
+func ParseString(data string) (elem Element, err error) {
+	return Parse(strings.NewReader(data))
+}
+
+// ParseCollection will parse a collection.
+func ParseCollectionString(data string) (elem CollectionElement, err error) {
+	return ParseCollection(strings.NewReader(data))
+}
+
+// Parse the string into an edn element.
+func Parse(data io.Reader) (elem Element, err error) {
 
 	var lex Lexer
 	if lex, err = getLexer(); err == nil {
@@ -42,7 +57,7 @@ func Parse(data string) (elem Element, err error) {
 }
 
 // ParseCollection will parse a collection.
-func ParseCollection(data string) (elem CollectionElement, err error) {
+func ParseCollection(data io.Reader) (elem CollectionElement, err error) {
 
 	var rawElem Element
 	if rawElem, err = Parse(data); err == nil {

--- a/edn/parser_test.go
+++ b/edn/parser_test.go
@@ -86,7 +86,9 @@ func message(ser Serializer, label string, index int, test *testInstance, elem E
 		v, _ := exp()
 		if m, e := NewMap(); e == nil {
 			for key, value := range v {
-				m.Append(NewStringElement(key), value)
+				if e := m.Append(NewStringElement(key), value); e != nil {
+					panic(e)
+				}
 			}
 			if expected, e = m.Serialize(ser); e != nil {
 				panic(e)
@@ -171,7 +173,7 @@ func runParserTests(elemType ElementType, definitions ...*testDefinition) {
 
 		for index, testCase := range tests {
 			It(fmt.Sprintf("should parse the expressions: `%s`", testCase.expression), func() {
-				elem, err := Parse(testCase.expression)
+				elem, err := ParseString(testCase.expression)
 				Ω(err).Should(BeNil(), message(ser, "err", index, testCase, elem))
 				Ω(elem).ShouldNot(BeNil(), message(ser, "elem", index, testCase, elem))
 				Ω(elem.ElementType()).Should(BeEquivalentTo(testCase.elemType), message(ser, "type", index, testCase, elem))
@@ -306,11 +308,11 @@ var _ = Describe("Collection Parser", func() {
 		var coll CollectionElement
 		var err error
 
-		coll, err = ParseCollection("[]")
+		coll, err = ParseCollectionString("[]")
 		Ω(err).Should(BeNil())
 		Ω(coll).ShouldNot(BeNil())
 
-		coll, err = ParseCollection("42")
+		coll, err = ParseCollectionString("42")
 		Ω(err).ShouldNot(BeNil())
 		Ω(coll).Should(BeNil())
 		Ω(err).Should(test.HaveMessage(ErrParserError))


### PR DESCRIPTION

## Description of Changes

 - `Parse` now takes in the reader, `ParseString` was added to be a nicer interface for strings.
 - Updates the tests to cover 100% for this area.
 - Changed tests to use the appropriate `Parse`, `ParseString` functions.
 - Cleaned up the function for debugging patterns.
 - Made the lexer more "idiomatic go".
 - Covered some error missing error handling in the test cases.

## Proposed Testing Steps (If Applicable)

  - Run the current set of tests.

## Relevant Issues (If Applicable)

  - None

## Maintainer Notifications

  - This is part of a larger effort to clean up the EDN parser.
